### PR TITLE
Fix counter splitting

### DIFF
--- a/zaehler/src/create_counter_image.php
+++ b/zaehler/src/create_counter_image.php
@@ -69,17 +69,10 @@ elseif($counter_quell_datei_typ=="image/gif" && is_callable('imagecreatefromgif'
 elseif(!is_callable('imagecreatefromgif') && $counter_quell_datei_typ=='image/gif') show_error(L_COUNTER_GIF_NOT_SUPPORTED);
 else show_error(L_COUNTER_TYPE_NOT_SUPPORTED);
 // Vornullen werden angefuegt
-if(strlen($counter_value)<$config_counter_digits)
- {
- while(strlen($counter_value)<$config_counter_digits)
-  {
-  $counter_value="0".$counter_value;
-  }
- }
- 
+$counter_value = str_pad($counter_value, $config_counter_digits, '0', STR_PAD_LEFT);
+
 // Ziffern werden auseinander genommen
-$counter_value=chunk_split($counter_value,1,' ');
-$counter_value=explode(' ',$counter_value);
+$counter_value=str_split($counter_value);
 // fuer jede Ziffer wird die Entsprechende Grafik aus der Countergrafik kopiert
 foreach($counter_value as $counter_stelle => $counter_ziffer)
  {


### PR DESCRIPTION
The splitting of the counter value[1] creates an array with an excess
element, namely an empty string.  This causes a "A non well formed
numeric value encountered " notice as of PHP 7.1 in the following
`foreach` loop.  This can be easily avoided by using `str_split()`,
which also simplifies the code.

We also simplify the zero padding immediately before the splitting code
by using `str_pad()`.

[1] <https://github.com/schmatzler/crazystat/blob/09ac03f32e7c918457ee7432819b44e05719f29f/zaehler/src/create_counter_image.php#L81-L82>